### PR TITLE
Add flattened namespace option

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,3 +157,19 @@ The set of symbol types are:
 - `StubsGenerator::CONSTANTS`: Constant declarations.
 - `StubsGenerator::DEFAULT`: Shortcut to include everything _except_ undocumented global variables.
 - `StubsGenerator::ALL`: Shortcut to include everything.
+
+#### Flatten namespaces
+
+To generate stubs without namespace blocks, enable the `strip_namespaces` option:
+
+```php
+$generator = new StubsGenerator(StubsGenerator::ALL, ['strip_namespaces' => true]);
+```
+
+From the command line:
+
+```bash
+generate-stubs --strip-namespaces /path/to/my-library
+```
+
+The output will omit `namespace { ... }` blocks entirely. This is useful for simple autocompletion but may produce invalid PHP when namespaced declarations share the same name.

--- a/src/GenerateStubsCommand.php
+++ b/src/GenerateStubsCommand.php
@@ -63,6 +63,7 @@ class GenerateStubsCommand extends Command
             ->addOption('header', null, InputOption::VALUE_REQUIRED, 'A doc comment to prepend to the top of the generated stubs file.  (Will be added below the opening `<?php` tag.)', '')
             ->addOption('nullify-globals', null, InputOption::VALUE_NONE, 'Initialize all global variables with a value of `null`, instead of their assigned value.')
             ->addOption('include-inaccessible-class-nodes', null, InputOption::VALUE_NONE, 'Include inaccessible class nodes like private members.')
+            ->addOption('strip-namespaces', null, InputOption::VALUE_NONE, 'Strip namespace declarations from the output.')
             ->addOption('stats', null, InputOption::VALUE_NONE, 'Whether to print stats instead of outputting stubs.  Stats will always be printed if --out is provided.');
 
         foreach (self::SYMBOL_OPTIONS as $opt) {
@@ -118,7 +119,8 @@ class GenerateStubsCommand extends Command
         $finder = $this->parseSources($input);
         $generator = new StubsGenerator($this->parseSymbols($input), [
             'nullify_globals' => $input->getOption('nullify-globals'),
-            'include_inaccessible_class_nodes' => $input->getOption('include-inaccessible-class-nodes')
+            'include_inaccessible_class_nodes' => $input->getOption('include-inaccessible-class-nodes'),
+            'strip_namespaces' => $input->getOption('strip-namespaces')
         ]);
 
         $result = $generator->generate($finder, $visitor);

--- a/src/NodeVisitor.php
+++ b/src/NodeVisitor.php
@@ -51,6 +51,8 @@ class NodeVisitor extends NodeVisitorAbstract
     private $nullifyGlobals;
     /** @var bool */
     private $includeInaccessibleClassNodes;
+    /** @var bool */
+    private $stripNamespaces;
 
     /**
      * @psalm-suppress PropertyNotSetInConstructor
@@ -106,6 +108,7 @@ class NodeVisitor extends NodeVisitorAbstract
 
         $this->nullifyGlobals = !empty($config['nullify_globals']);
         $this->includeInaccessibleClassNodes = ($config['include_inaccessible_class_nodes'] ?? false) === true;
+        $this->stripNamespaces = ($config['strip_namespaces'] ?? false) === true;
 
         $this->globalNamespace = new Namespace_();
     }
@@ -303,7 +306,7 @@ class NodeVisitor extends NodeVisitorAbstract
             $this->resolveClassLike($classLike);
         }
 
-        if ($this->allAreGlobal($this->namespaces) && $this->allAreGlobal($this->classLikeNamespaces)) {
+        if ($this->stripNamespaces || ($this->allAreGlobal($this->namespaces) && $this->allAreGlobal($this->classLikeNamespaces))) {
             return array_merge(
                 $this->reduceStmts($this->classLikeNamespaces),
                 $this->reduceStmts($this->namespaces),

--- a/test/NodeVisitorTest.php
+++ b/test/NodeVisitorTest.php
@@ -46,6 +46,7 @@ class NodeVisitorTest extends TestCase
             ['globals', 'globals.nullified', StubsGenerator::GLOBALS, [ 'nullify_globals' => true ]],
             'junk',
             'namespaces',
+            ['namespaces', 'namespaces.flat', null, ['strip_namespaces' => true]],
             'constants',
         ];
 

--- a/test/files/namespaces.flat.out.php
+++ b/test/files/namespaces.flat.out.php
@@ -1,0 +1,25 @@
+<?php
+class A extends \B\B implements \D
+{
+    const A = \B\B::A * 5;
+    const B = GLOBAL_FALLBACK;
+    const C = \GLOBAL_EXPLICIT;
+
+    public function a($a = \B\B::A) : \B\B
+    {
+    }
+}
+class A extends \C implements \D\D
+{
+    const A = \B\B;
+    const B = \GLOBAL_FALLBACK;
+    const C = \GLOBAL_EXPLICIT;
+}
+function a()
+{
+}
+function a()
+{
+}
+
+$a = 'a';


### PR DESCRIPTION
## Summary
- allow stripping of namespace blocks via `strip_namespaces`
- expose `--strip-namespaces` option on the CLI
- document how to flatten namespaces
- test flattening behaviour