### PR TITLE
Add strict typing declarations

### DIFF
--- a/bin/generate-stubs
+++ b/bin/generate-stubs
@@ -1,5 +1,6 @@
 #!/usr/bin/env php
 <?php
+declare(strict_types=1);
 
 foreach ([__DIR__ . '/../../../autoload.php', __DIR__ . '/../vendor/autoload.php'] as $file) {
     if (file_exists($file)) {

--- a/src/ClassLikeWithDependencies.php
+++ b/src/ClassLikeWithDependencies.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace StubsGenerator;
 
 use PhpParser\Node\Name;

--- a/src/Finder.php
+++ b/src/Finder.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace StubsGenerator;
 
 use Symfony\Component\Finder\Finder as SymfonyFinder;

--- a/src/GenerateStubsCommand.php
+++ b/src/GenerateStubsCommand.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace StubsGenerator;
 
 use ArrayIterator;

--- a/src/NodeVisitor.php
+++ b/src/NodeVisitor.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace StubsGenerator;
 
 use PhpParser\Node;

--- a/src/Result.php
+++ b/src/Result.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace StubsGenerator;
 
 use ArrayIterator;

--- a/src/StubsGenerator.php
+++ b/src/StubsGenerator.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace StubsGenerator;
 
 use PhpParser\Error;


### PR DESCRIPTION
## Résumé
Ajout de `declare(strict_types=1);` au début de tous les fichiers PHP situés dans `src/` et `bin/`.