### PR TITLE
Set explicit NodeVisitor return types

### DIFF
--- a/src/NodeVisitor.php
+++ b/src/NodeVisitor.php
@@ -113,12 +113,12 @@ class NodeVisitor extends NodeVisitorAbstract
         $this->globalNamespace = new Namespace_();
     }
 
-    public function beforeTraverse(array $nodes)
+    public function beforeTraverse(array $nodes): void
     {
         $this->stack = [];
     }
 
-    public function enterNode(Node $node)
+    public function enterNode(Node $node): Node|int|null
     {
         $this->stack[] = $node;
 
@@ -193,7 +193,7 @@ class NodeVisitor extends NodeVisitorAbstract
         }
     }
 
-    public function leaveNode(Node $node, bool $preserveStack = false)
+    public function leaveNode(Node $node, bool $preserveStack = false): Node|int|null
     {
         if (!$preserveStack) {
             array_pop($this->stack);
@@ -218,18 +218,14 @@ class NodeVisitor extends NodeVisitorAbstract
         }
 
         if ($node instanceof If_) {
-            // Replace the if statement with its set of children, but only those
-            // that we want.  Have to manually call leaveNode on each; it won't
-            // be called automatically..
-            $stmts = [];
+            // Replace the if statement with its children, keeping only those
+            // deemed necessary.
             foreach ($node->stmts as $stmt) {
-                if ($this->leaveNode($stmt, true) !== NodeTraverser::REMOVE_NODE) {
-                    $stmt = $stmt;
-                }
+                $this->leaveNode($stmt, true);
             }
             // We're leaving it.
             $this->isInIf = false;
-            return $stmts;
+            return NodeTraverser::REMOVE_NODE;
         }
 
         if ($node instanceof Namespace_) {
@@ -287,7 +283,7 @@ class NodeVisitor extends NodeVisitorAbstract
         return NodeTraverser::REMOVE_NODE;
     }
 
-    public function afterTraverse(array $nodes)
+    public function afterTraverse(array $nodes): void
     {
         // Don't keep any empty namespaces.
         $this->namespaces = array_filter($this->namespaces, function (Namespace_ $ns): bool {


### PR DESCRIPTION
## Summary
- specify explicit return types for NodeVisitor lifecycle hooks
- adjust logic for removing `if` nodes