### PR TITLE
Add return type annotations to stubs

### DIFF
--- a/src/NodeVisitor.php
+++ b/src/NodeVisitor.php
@@ -119,6 +119,9 @@ class NodeVisitor extends NodeVisitorAbstract
         $this->stack = [];
     }
 
+    /**
+     * @return Node|int|null
+     */
     public function enterNode(Node $node)
     {
         $this->stack[] = $node;
@@ -194,6 +197,9 @@ class NodeVisitor extends NodeVisitorAbstract
         }
     }
 
+    /**
+     * @return Node|int|null
+     */
     public function leaveNode(Node $node, bool $preserveStack = false)
     {
         if (!$preserveStack) {

--- a/src/ReturnTypeCopyVisitor.php
+++ b/src/ReturnTypeCopyVisitor.php
@@ -1,0 +1,69 @@
+<?php
+declare(strict_types=1);
+namespace StubsGenerator;
+
+use PhpParser\Comment\Doc;
+use PhpParser\Node;
+use PhpParser\Node\FunctionLike;
+use PhpParser\Node\Identifier;
+use PhpParser\Node\Name;
+use PhpParser\Node\NullableType;
+use PhpParser\Node\UnionType;
+use PhpParser\Node\IntersectionType;
+use PhpParser\NodeVisitorAbstract;
+
+/**
+ * Adds a @return annotation when a function or method has a return type.
+ */
+class ReturnTypeCopyVisitor extends NodeVisitorAbstract
+{
+    public function enterNode(Node $node)
+    {
+        if ($node instanceof FunctionLike && $node->getReturnType()) {
+            $doc = $node->getDocComment();
+            if ($doc && strpos($doc->getText(), '@return') !== false) {
+                return null;
+            }
+
+            $typeString = $this->formatType($node->getReturnType());
+            $commentLines = $doc ? preg_split('/\r?\n/', $doc->getText()) : ['/**', ' */'];
+            $end = array_pop($commentLines);
+            if (trim($end) !== '*/') {
+                $commentLines[] = $end;
+            }
+            $commentLines[] = ' * @return ' . $typeString;
+            $commentLines[] = ' */';
+            $node->setDocComment(new Doc(implode("\n", $commentLines)));
+        }
+
+        return null;
+    }
+
+    private function formatType($type): string
+    {
+        if ($type instanceof NullableType) {
+            return '?' . $this->formatType($type->type);
+        }
+        if ($type instanceof UnionType) {
+            $parts = [];
+            foreach ($type->types as $t) {
+                $parts[] = $this->formatType($t);
+            }
+            return implode('|', $parts);
+        }
+        if ($type instanceof IntersectionType) {
+            $parts = [];
+            foreach ($type->types as $t) {
+                $parts[] = $this->formatType($t);
+            }
+            return implode('&', $parts);
+        }
+        if ($type instanceof Name) {
+            return '\\' . ltrim($type->toString(), '\\');
+        }
+        if ($type instanceof Identifier) {
+            return $type->name;
+        }
+        return '';
+    }
+}

--- a/src/StubsGenerator.php
+++ b/src/StubsGenerator.php
@@ -5,6 +5,7 @@ namespace StubsGenerator;
 use PhpParser\Error;
 use PhpParser\NodeTraverser;
 use PhpParser\NodeVisitor\NameResolver;
+use StubsGenerator\ReturnTypeCopyVisitor;
 use PhpParser\ParserFactory;
 use RuntimeException;
 use Symfony\Component\Finder\Finder;
@@ -123,6 +124,7 @@ class StubsGenerator
 
         $traverser = new NodeTraverser();
         $traverser->addVisitor(new NameResolver());
+        $traverser->addVisitor(new ReturnTypeCopyVisitor());
         $traverser->addVisitor($visitor);
 
         $unparsed = [];


### PR DESCRIPTION
## Summary
- document NodeVisitor enter/leave methods with `@return Node|int|null`
- implement `ReturnTypeCopyVisitor` to copy return type into `@return` annotation
- register `ReturnTypeCopyVisitor` in `StubsGenerator`